### PR TITLE
Fix ability to check a single repository

### DIFF
--- a/gdc
+++ b/gdc
@@ -38,7 +38,7 @@ def ensure_str(s):
 full_names = []
 
 if len(sys.argv) == 3:
-    full_names[0] = sys.argv[1] + "/" + sys.argv[1]
+    full_names.append(sys.argv[1] + "/" + sys.argv[2])
 else:
     buf = cStringIO.StringIO()
     r = requests.get('https://api.github.com/users/' + sys.argv[1] + "/repos")


### PR DESCRIPTION
Checking a single repository instead of an entire account was
failing for two reasons.
1. It is not possible to assign something to the first element of
   an empty list. This commit switches to 'append'
2. There was a typo leading to the username rather than the
   repository being appended to the username.
