### PR TITLE
unhardwire the python path: /usr/bin/python -> /usr/bin/env python

### DIFF
--- a/gdc
+++ b/gdc
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import sys
 


### PR DESCRIPTION
This allows it to be run under pyenv via:

```
./gdc ...
```

\- rather than:

```
python ./gdc ...
```
